### PR TITLE
Add description for container registry.

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,8 @@ A example is in [here](./test/kubernetes/).
 
 ### Sidecar Pattern
 
-Prometheus Go Exporter must be shared the directory specified by PASSENGER_INSTANCE_REGISTRY_DIR with passenger application.
+Container images can be pulled from [ghcr.io/rakutentech/passenger-go-exporter](https://github.com/orgs/rakutentech/packages/container/package/passenger-go-exporter).<br>
+Passsenger Go Exporter must be shared the directory specified by PASSENGER_INSTANCE_REGISTRY_DIR with passenger application.
 
 Passenger Application side defines `PASSENGER_INSTANCE_REGISTRY_DIR` environment varibles,
 and specify emptyDir volume.
@@ -33,18 +34,18 @@ Passenger Go Exporter side defines similarly.
         - name: example
           env:
             - name: PASSENGER_INSTANCE_REGISTRY_DIR
-              value: /tmp
+              value: /tmp/ruby
           volumeMounts:
-            - mountPath: /tmp
+            - mountPath: /tmp/ruby
               name: tmp
         - name: passenger-exporter
-          image: passenger-exporter
+          image: ghcr.io/rakutentech/passenger-go-exporter:v1.1.0
           imagePullPolicy: IfNotPresent
           env:
             - name: PASSENGER_INSTANCE_REGISTRY_DIR
-              value: /tmp
+              value: /tmp/ruby
           volumeMounts:
-            - mountPath: /tmp
+            - mountPath: /tmp/ruby
               name: tmp
 ```
 

--- a/test/kubernetes/base/deployment.yaml
+++ b/test/kubernetes/base/deployment.yaml
@@ -41,16 +41,16 @@ spec:
               port: 3000
           env:
             - name: PASSENGER_INSTANCE_REGISTRY_DIR
-              value: /tmp
+              value: /tmp/ruby
           volumeMounts:
-            - mountPath: /tmp
+            - mountPath: /tmp/ruby
               name: tmp
         - name: passenger-exporter
           image: passenger-exporter
           imagePullPolicy: IfNotPresent
           env:
             - name: PASSENGER_INSTANCE_REGISTRY_DIR
-              value: /tmp
+              value: /tmp/ruby
           ports:
             - containerPort: 9768
               name: http
@@ -74,5 +74,5 @@ spec:
               cpu: 20m
               memory: 60Mi
           volumeMounts:
-            - mountPath: /tmp
+            - mountPath: /tmp/ruby
               name: tmp

--- a/test/kubernetes/example/kustomization.yaml
+++ b/test/kubernetes/example/kustomization.yaml
@@ -5,5 +5,5 @@ images:
     newName: PLEASE_CHANGE_VALUE
     newTag: PLEASE_CHANGE_VALUE
   - name: passenger-exporter
-    newName: PLEASE_CHANGE_VALUE 
-    newTag: PLEASE_CHANGE_VALUE
+    newName: ghcr.io/rakutentech/passenger-go-exporter 
+    newTag: v1.1.0


### PR DESCRIPTION
#### Summary
I mentioned that the container image can be pulled from GHCR.

There was a problem with Docker for Mac that caused an error when the rootDir of emptyDir was set to PASSENGER_INSTANCE_REGISTRY_DIR, so the examples has been fixed.

#### Related issue or URL
closed: #12 

#### Self Checklist

- [x] `go fmt ./...` is done.
- [x] `golint ./...` is nothing message.
- [x] `go test -v ./...` is all success.

