### PR TITLE
Bump golang up to 1.23

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.22 AS builder
+FROM golang:1.23 AS builder
 WORKDIR /go/src/github.com/rakutentech/passenger-go-exporter
 
 COPY go.mod go.sum ./

--- a/README.md
+++ b/README.md
@@ -6,8 +6,8 @@ Implemented in golang, keeps memory consumption below 100MB, and runs on CPU 0.0
 
 ## Supported version
 
-- golang: 1.22
-- Passenger: 6.0.18, or later.
+- golang: 1.23
+- Passenger: 6.0.23, or later.
 
 All other versions have not been tested.
 
@@ -39,7 +39,7 @@ Passenger Go Exporter side defines similarly.
             - mountPath: /tmp/ruby
               name: tmp
         - name: passenger-exporter
-          image: ghcr.io/rakutentech/passenger-go-exporter:v1.4.2
+          image: ghcr.io/rakutentech/passenger-go-exporter:v1.4.4
           imagePullPolicy: IfNotPresent
           env:
             - name: PASSENGER_INSTANCE_REGISTRY_DIR

--- a/test/kubernetes/base/deployment.yaml
+++ b/test/kubernetes/base/deployment.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: example
 spec:
+  replicas: 0
   strategy:
     rollingUpdate:
       maxUnavailable: 25%
@@ -19,60 +20,61 @@ spec:
       labels:
         app: example
     spec:
+
       volumes:
-        - name: tmp
-          emptyDir: {}
+      - name: tmp
+        emptyDir: {}
       containers:
-        - name: example
-          image: example
-          imagePullPolicy: IfNotPresent
-          ports:
-            - containerPort: 3000
-              name: http
-              protocol: TCP
-          livenessProbe:
-            httpGet:
-              path: /
-              port: 3000
-          readinessProbe:
-            timeoutSeconds: 2
-            httpGet:
-              path: /
-              port: 3000
-          env:
-            - name: PASSENGER_INSTANCE_REGISTRY_DIR
-              value: /tmp/ruby
-          volumeMounts:
-            - mountPath: /tmp/ruby
-              name: tmp
-        - name: passenger-exporter
-          image: passenger-exporter
-          imagePullPolicy: IfNotPresent
-          env:
-            - name: PASSENGER_INSTANCE_REGISTRY_DIR
-              value: /tmp/ruby
-          ports:
-            - containerPort: 9768
-              name: http
-              protocol: TCP
-          livenessProbe:
-            initialDelaySeconds: 10
-            timeoutSeconds: 2
-            httpGet:
-              path: /health
-              port: 9768
-          readinessProbe:
-            timeoutSeconds: 1
-            httpGet:
-              path: /health
-              port: 9768
-          resources:
-            limits:
-              cpu: 20m
-              memory: 60Mi
-            requests:
-              cpu: 20m
-              memory: 60Mi
-          volumeMounts:
-            - mountPath: /tmp/ruby
-              name: tmp
+      - name: example
+        image: example
+        imagePullPolicy: IfNotPresent
+        ports:
+        - containerPort: 3000
+          name: http
+          protocol: TCP
+        livenessProbe:
+          httpGet:
+            path: /
+            port: 3000
+        readinessProbe:
+          timeoutSeconds: 2
+          httpGet:
+            path: /
+            port: 3000
+        env:
+        - name: PASSENGER_INSTANCE_REGISTRY_DIR
+          value: /tmp/ruby
+        volumeMounts:
+        - mountPath: /tmp/ruby
+          name: tmp
+      - name: passenger-exporter
+        image: passenger-exporter
+        imagePullPolicy: IfNotPresent
+        env:
+        - name: PASSENGER_INSTANCE_REGISTRY_DIR
+          value: /tmp/ruby
+        ports:
+        - containerPort: 9768
+          name: http
+          protocol: TCP
+        livenessProbe:
+          initialDelaySeconds: 10
+          timeoutSeconds: 2
+          httpGet:
+            path: /health
+            port: 9768
+        readinessProbe:
+          timeoutSeconds: 1
+          httpGet:
+            path: /health
+            port: 9768
+        resources:
+          limits:
+            cpu: 20m
+            memory: 60Mi
+          requests:
+            cpu: 20m
+            memory: 60Mi
+        volumeMounts:
+        - mountPath: /tmp/ruby
+          name: tmp


### PR DESCRIPTION
#### Summary
Version up to 1.23

#### Related issue or URL


#### Self Checklist

- [x] `go fmt ./...` was done.
- [x] `golangci-lint run` ran with nothing warnings and errors.
- [x] `go test -v ./...` was all success.

